### PR TITLE
wait for gpio device to spawn before echo

### DIFF
--- a/reset-ec.sh
+++ b/reset-ec.sh
@@ -5,6 +5,7 @@ then
     echo "25" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio25/direction
 echo 0 > /sys/class/gpio/gpio25/value
 sleep 0.1

--- a/reset-soc.sh
+++ b/reset-soc.sh
@@ -5,6 +5,7 @@ then
     echo "24" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio24/direction
 echo 0 > /sys/class/gpio/gpio24/value
 sleep 0.1

--- a/uart_fpga.sh
+++ b/uart_fpga.sh
@@ -5,5 +5,6 @@ then
     echo "18" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio18/direction
 echo "1" > /sys/class/gpio/gpio18/value

--- a/uart_up5k.sh
+++ b/uart_up5k.sh
@@ -5,5 +5,6 @@ then
     echo "18" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio18/direction
 echo "0" > /sys/class/gpio/gpio18/value

--- a/vbus.sh
+++ b/vbus.sh
@@ -10,5 +10,6 @@ then
     echo "21" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio21/direction
 echo $1 > /sys/class/gpio/gpio21/value

--- a/vbus_off.sh
+++ b/vbus_off.sh
@@ -5,5 +5,6 @@ then
     echo "21" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio21/direction
 echo "0" > /sys/class/gpio/gpio21/value

--- a/vbus_on.sh
+++ b/vbus_on.sh
@@ -5,5 +5,6 @@ then
     echo "21" > /sys/class/gpio/export
 fi
 
+sleep 0.1
 echo "out" > /sys/class/gpio/gpio21/direction
 echo "1" > /sys/class/gpio/gpio21/value


### PR DESCRIPTION
Without the `sleep 0.1`, these scripts can give errors like this:
```
./reset-ec.sh: 8: ./reset-ec.sh: cannot create /sys/class/gpio/gpio25/direction: Permission denied
./reset-ec.sh: 9: ./reset-ec.sh: cannot create /sys/class/gpio/gpio25/value: Permission denied
./reset-ec.sh: 11: echo: echo: I/O error
```

The problem only happens for the first run of the scripts after Pi is booted.