### PR TITLE
Add script for UP5K serial debug 'wishbone-tool -s terminal...'

### DIFF
--- a/start-xover-uart-up5k.sh
+++ b/start-xover-uart-up5k.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -x
+./uart_up5k.sh
+./reset-ec.sh \
+    && sleep 0.1 \
+    && wishbone-tool --uart /dev/serial0 -b 115200 -s terminal --csr-csv=../precursors/csr.csv


### PR DESCRIPTION
This automates the timing sensitive task of reseting the UP5K and starting a wishbone-tool crossover UART bridge. Currently, the connection needs to start in the time window between when the bitstream loads (~50ms) and when the firmware locks up without a bridge connection (~2000ms). The lockup may be due to the crossover UART TX buffer filling up -- not sure.

This is meant to be used after flashing a Precursor handset with EC gateware & firmware that have been re-built to have the serial debug features enabled by:
1. Changing `debugonly = False` to `debugonly = True` in `betrusted-ec/betrusted_ec.py`
2. Changing `default = []` to `default = ["debug_uart"]` in `betrusted-ec/sw/Cargo.toml`