### PR TITLE
Switch UP5K serial from wishbone-tool to screen

### DIFF
--- a/start_gdb_up5k.sh
+++ b/start_gdb_up5k.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-wishbone-tool --uart /dev/ttyS0 -b 115200 -s gdb --bind-addr 0.0.0.0 -s terminal --csr-csv=../precursors/ec-csr.csv

--- a/start_screen_up5k.sh
+++ b/start_screen_up5k.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "Starting serial terminal emulator (screen)..."
+echo "  To exit screen, use Ctrl-A k"
+sleep 2
+set -x
+./uart_up5k.sh
+sleep 0.1
+screen /dev/serial0 115200

--- a/start_xover_uart_up5k.sh
+++ b/start_xover_uart_up5k.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -x
-./uart_up5k.sh
-./reset_ec.sh \
-    && sleep 0.1 \
-    && wishbone-tool --uart /dev/serial0 -b 115200 -s terminal --csr-csv=../precursors/csr.csv


### PR DESCRIPTION
This change updates the serial helper scripts to reflect that, as of yesterday, the EC gateware build no longer includes gdb support using a Wishbone bridge on the serial port. Now the UP5K serial port pins are now wired up to a plain 115200 8N1 UART.