### PR TITLE
Start screen with XON/XOFF flow-control disabled

### DIFF
--- a/start_screen_up5k.sh
+++ b/start_screen_up5k.sh
@@ -2,7 +2,9 @@
 echo "Starting serial terminal emulator (screen)..."
 echo "  To exit screen, use Ctrl-A k"
 sleep 2
-set -x
 ./uart_up5k.sh
-sleep 0.1
-screen /dev/serial0 115200
+# Using -fn turns off screen's default automatic XON/XOFF flow control. Auto
+# flow control can unpredictably interrupt the serial debug log, resulting in a
+# blank serial terminal screen, an unresponsive keyboard, and no indication of
+# what went wrong.
+screen -fn /dev/serial0 115200


### PR DESCRIPTION
This changes the `start_screen_up5k.sh` script to start screen with its default auto flow-control mode turned off (`-fn` switch). 

With XON/XOFF flow control turned off, switching between the UP5K and XC7S serial debug ports is more reliable. Previously, screen would sometimes get stuck on a blank serial terminal window with an unresponsive keyboard. This seems better so far, but I haven't tested it extensively.