### PR TITLE
README: add missing dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ While it creates no files or intentionally permanent record of the key, if you a
 
 ## Prerequisites
 
-You will need to install the following packages:
+You will need to install the following packages  (installed via `pip3 install` or `pip install` based on your distro):
 
-- `pexpect` (installed via `pip3 install` or `pip install` based on your distro)
-- `pycrypto` (installed via `pip3 install` or `pip install` based on your distro)
+- `pexpect`
+- `pycrypto`
+- `cffi`
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ While it creates no files or intentionally permanent record of the key, if you a
 You will need to install the following packages:
 
 - `pexpect` (installed via `pip3 install` or `pip install` based on your distro)
+- `pycrypto` (installed via `pip3 install` or `pip install` based on your distro)
 
 ## Running
 


### PR DESCRIPTION
without this I get `ModuleNotFound: no module named 'Crypto'` when running `./provision_xous.sh`.