### PR TITLE
fhs: fix fhseries

### DIFF
--- a/fetch_stable_images.sh
+++ b/fetch_stable_images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 mkdir -p ../precursors

--- a/provision_xous.sh
+++ b/provision_xous.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "WARNING: this script is for un-bricking devices, and will overwrite any secret keys stored in the gateware"
 


### PR DESCRIPTION
fhseries is the term *I use* to design strong Filesystem Hierarchy Standard assumptions which are not true on all Linux distributions. Notably: NixOS and Guix.

Opened as a draft as I am still going through it as I am unbricking my Precursor.