### PR TITLE
Make the bbram helper password timeout much more generous

### DIFF
--- a/bbram_helper.py
+++ b/bbram_helper.py
@@ -552,7 +552,7 @@ def main():
 
     print("You may need to enter the update password on the Precursor device now; do not type the password here!")
     
-    console.expect_exact(CONSOLE_SENTINEL, 60)
+    console.expect_exact(CONSOLE_SENTINEL, 15*60)
     log = console.before.decode('utf-8')
     bbram_copies = []
     for line in log.split('\n'):


### PR DESCRIPTION
Increases the bbram helper's password timeout to a much more generous 15 minutes.

Use case: I have a very long update password that takes a while to enter on the tiny keyboard. I also have to access my safe to find that password, which takes a few minutes.